### PR TITLE
Bootstrap using local IPFS client.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.4
 	github.com/ipfs/boxo v0.24.3
 	github.com/ipfs/go-cid v0.5.0
-	github.com/ipfs/go-ipld-format v0.6.0
 	github.com/ipfs/kubo v0.31.0
 	github.com/libp2p/go-libp2p v0.38.2
 	github.com/libp2p/go-libp2p-kad-dht v0.28.1
@@ -70,6 +69,7 @@ require (
 	github.com/ipfs/go-ipfs-cmds v0.14.1 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.3 // indirect
 	github.com/ipfs/go-ipld-cbor v0.2.0 // indirect
+	github.com/ipfs/go-ipld-format v0.6.0 // indirect
 	github.com/ipfs/go-ipld-legacy v0.2.1 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect


### PR DESCRIPTION
`glia.P2P.Bootstrap` dynamically creates a `boot.StaticAddr` using `p2p.Env.IPFS.Swarm()`.  In effect, we treat peers of our IPFS node as bootstrap nodes for Wetware's DHT.  This works so long as Wetware uses the public IPFS DHT for resolving hosts.