### PR TITLE
Remove bootstrap code from glia and provide bootstrap nodes to DHT.

### DIFF
--- a/cmd/ww/main.go
+++ b/cmd/ww/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-kad-dht/dual"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/lmittmann/tint"
@@ -91,16 +90,8 @@ func setup(c *cli.Context) (err error) {
 	}
 
 	env.DHT, err = dual.New(c.Context, env.Host,
-		dual.WanDHTOption(
-			// IPFS public bootstrap nodes
-			dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...)),
-		dual.LanDHTOption(
-			dht.BootstrapPeersFunc(func() (ps []peer.AddrInfo) {
-				for _, id := range env.Host.Peerstore().Peers() {
-					ps = append(ps, env.Host.Peerstore().PeerInfo(id))
-				}
-				return
-			})))
+		dual.WanDHTOption(dht.BootstrapPeersFunc(env.PublicBootstrapPeers)),
+		dual.LanDHTOption(dht.BootstrapPeersFunc(env.PrivateBootstrapPeers)))
 	if err != nil {
 		return
 	}

--- a/cmd/ww/main.go
+++ b/cmd/ww/main.go
@@ -46,6 +46,12 @@ func main() {
 				Value:   "ww",
 				Usage:   "cluster namespace",
 			},
+			&cli.StringSliceFlag{
+				Name:    "addr",
+				EnvVars: []string{"WW_ADDRS"},
+				Aliases: []string{"a"},
+				Usage:   "peer addr to dial",
+			},
 			&cli.BoolFlag{
 				Name:    "json",
 				EnvVars: []string{"WW_JSON"},

--- a/glia/http.go
+++ b/glia/http.go
@@ -186,7 +186,8 @@ func (h *HTTP) glia(w http.ResponseWriter, r *http.Request) {
 		ResponseWriter: w,
 		Request:        r,
 	}); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		h.Log().ErrorContext(r.Context(), "stream handler failed",
+			"reason", err)
 		return
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.4
 	github.com/ipfs/boxo v0.24.3
 	github.com/ipfs/go-cid v0.5.0
-	github.com/ipfs/go-ipld-format v0.6.0
 	github.com/ipfs/kubo v0.31.0
 	github.com/libp2p/go-libp2p v0.38.2
 	github.com/libp2p/go-libp2p-kad-dht v0.28.1
@@ -70,6 +69,7 @@ require (
 	github.com/ipfs/go-ipfs-cmds v0.14.1 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.3 // indirect
 	github.com/ipfs/go-ipld-cbor v0.2.0 // indirect
+	github.com/ipfs/go-ipld-format v0.6.0 // indirect
 	github.com/ipfs/go-ipld-legacy v0.2.1 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect

--- a/system/env.go
+++ b/system/env.go
@@ -52,19 +52,6 @@ func (env Env) HandlePeerFound(info peer.AddrInfo) {
 		slog.Warn("bootstrap failed",
 			"reason", err)
 	}
-
-	// if err := env.Host.Connect(ctx, peer.AddrInfo{
-	// 	ID:    info.ID,
-	// 	Addrs: info.Addrs,
-	// }); err != nil {
-	// 	env.Log().Debug("failed to connect to peer",
-	// 		"reason", err,
-	// 		"peer", info.ID,
-	// 		"addrs", info.Addrs)
-	// } else if err := env.DHT.Bootstrap(ctx); err != nil {
-	// 	env.Log().Error("failed to bootstrap dht",
-	// 		"reason", err)
-	// }
 }
 
 func (env Env) Load(ctx context.Context, p string) ([]byte, error) {


### PR DESCRIPTION
Replaces https://github.com/wetware/go/pull/10.

This approach is much cleaner:  we pass bootstrap peers to the DHT, and remove all bootstrap code from glia.